### PR TITLE
22.12.31

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -205,6 +205,9 @@ header {
   outline: none;
 }
 .search-menu {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 50px 0 0 50px;
   margin-left: auto;
 }


### PR DESCRIPTION
*변경점
main-wrap width값이 1148px보다 내려가면
search-menu 버튼 정렬이 깨짐 현상 해결